### PR TITLE
Governance surface: further clean comment-finding

### DIFF
--- a/parse_contract_parameters.ipynb
+++ b/parse_contract_parameters.ipynb
@@ -38,7 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ERRORMSG = 'error: could not parse'"
+    "ERRORMSG = 'error: could not parse'\n",
+    "IGNORE_CONTRACTS = ['SafeMath']"
    ]
   },
   {
@@ -247,8 +248,9 @@
     "    the corresponding DataFrame.\n",
     "    \"\"\"\n",
     "    \n",
-    "    # Get list of contract nodes defined in Solidity file\n",
+    "    # Get list of relevant contract nodes defined in Solidity file\n",
     "    contracts = [c for c in sourceUnit['children'] if c.get('type') == 'ContractDefinition']\n",
+    "    contracts = [c for c in contracts if c['name'] not in IGNORE_CONTRACTS]\n",
     "    \n",
     "    df_objects = pd.DataFrame()\n",
     "    df_parameters = pd.DataFrame()\n",
@@ -491,7 +493,7 @@
     "        for key, value in commentDict.items():\n",
     "            if key in df_o.columns:\n",
     "                if key == 'param':\n",
-    "                    value = value.keys()\n",
+    "                    value = list(value.keys())\n",
     "                df_o.iat[i, df_o.columns.get_loc(key)] = value               \n",
     "\n",
     "        # Add parameter descriptions to parameters\n",
@@ -539,6 +541,34 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remove_duplicate_comments_in_parameters(df_o, df_parameters):\n",
+    "    \"\"\"Remove description and/or full comment for a parameter if it is \n",
+    "    the same as its parent object's description\"\"\"\n",
+    "    \n",
+    "    df_p = df_parameters.copy(deep=True)\n",
+    "    \n",
+    "    for i, row in df_parameters.iterrows():\n",
+    "        # Get parent object's comments\n",
+    "        index = df_o.loc[(df_o['object_name']==row['object_name']) &\n",
+    "                         (df_o['contract']==row['contract'])].index[0]\n",
+    "        object_fullComment = df_o.iat[index, df_o.columns.get_loc('full_comment')]\n",
+    "        object_description = df_o.iat[index, df_o.columns.get_loc('description')]\n",
+    "        \n",
+    "        # Delete parameter's comment(s) if duplicate of parent object's\n",
+    "        if (row['full_comment'] == object_fullComment) or ('@param' in object_fullComment):\n",
+    "            df_p.iat[i, df_p.columns.get_loc('full_comment')] = ''\n",
+    "        if row['description'] == object_description:\n",
+    "            df_p.iat[i, df_p.columns.get_loc('description')] = ''\n",
+    "        \n",
+    "    return df_p"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "VKbn80YV9Vf4"
@@ -549,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {
     "id": "CUCAX_cp3cRE"
    },
@@ -569,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -618,9 +648,12 @@
     "    # Add comments to the DataFrames\n",
     "    df_objects, df_parameters = add_docstring_comments(lines, df_objects, df_parameters)\n",
     "    df_parameters = add_inline_comments(lines, df_parameters)\n",
+    "    df_parameters = remove_duplicate_comments_in_parameters(df_objects, df_parameters)\n",
     "    \n",
+    "    # Add other identifying info\n",
     "    df_objects['url'] = url\n",
     "    \n",
+    "    # Save to full dfs\n",
     "    df_objects_all = df_objects_all.append(df_objects)\n",
     "    df_parameters_all = df_parameters_all.append(df_parameters)\n",
     "    \n",
@@ -629,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -691,7 +724,7 @@
        "      <td></td>\n",
        "      <td>Used to initialize the contract during delegat...</td>\n",
        "      <td></td>\n",
-       "      <td>(timelock_, comp_, votingPeriod_, votingDelay_...</td>\n",
+       "      <td>[timelock_, comp_, votingPeriod_, votingDelay_...</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -709,7 +742,7 @@
        "      <td></td>\n",
        "      <td>Function used to propose a new proposal. Sende...</td>\n",
        "      <td></td>\n",
-       "      <td>(targets, values, signatures, calldatas, descr...</td>\n",
+       "      <td>[targets, values, signatures, calldatas, descr...</td>\n",
        "      <td>Proposal id of new proposal</td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -727,7 +760,7 @@
        "      <td></td>\n",
        "      <td>Queues a proposal of state succeeded</td>\n",
        "      <td></td>\n",
-       "      <td>(proposalId)</td>\n",
+       "      <td>[proposalId]</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -745,7 +778,7 @@
        "      <td></td>\n",
        "      <td>Executes a queued proposal if eta has passed</td>\n",
        "      <td></td>\n",
-       "      <td>(proposalId)</td>\n",
+       "      <td>[proposalId]</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -763,7 +796,7 @@
        "      <td></td>\n",
        "      <td>Cancels a proposal only if sender is the propo...</td>\n",
        "      <td></td>\n",
-       "      <td>(proposalId)</td>\n",
+       "      <td>[proposalId]</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -799,7 +832,7 @@
        "      <td></td>\n",
        "      <td>Transfer `amount` tokens from `src` to `dst`</td>\n",
        "      <td></td>\n",
-       "      <td>(src, dst, rawAmount)</td>\n",
+       "      <td>[src, dst, rawAmount]</td>\n",
        "      <td>Whether or not the transfer succeeded</td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -817,7 +850,7 @@
        "      <td></td>\n",
        "      <td>Delegate votes from `msg.sender` to `delegatee`</td>\n",
        "      <td></td>\n",
-       "      <td>(delegatee)</td>\n",
+       "      <td>[delegatee]</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -835,7 +868,7 @@
        "      <td></td>\n",
        "      <td>Delegates votes from signatory to `delegatee`</td>\n",
        "      <td></td>\n",
-       "      <td>(delegatee, nonce, expiry, v, r, s)</td>\n",
+       "      <td>[delegatee, nonce, expiry, v, r, s]</td>\n",
        "      <td></td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -853,7 +886,7 @@
        "      <td></td>\n",
        "      <td>Gets the current votes balance for `account`</td>\n",
        "      <td></td>\n",
-       "      <td>(account)</td>\n",
+       "      <td>[account]</td>\n",
        "      <td>The number of current votes for `account`</td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
@@ -871,14 +904,14 @@
        "      <td></td>\n",
        "      <td>Determine the prior number of votes for an acc...</td>\n",
        "      <td>Block number must be a finalized block or else...</td>\n",
-       "      <td>(account, blockNumber)</td>\n",
+       "      <td>[account, blockNumber]</td>\n",
        "      <td>The number of votes the account had as of the ...</td>\n",
        "      <td>https://raw.githubusercontent.com/notchia/meta...</td>\n",
        "      <td>Governor Bravo</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>80 rows × 15 columns</p>\n",
+       "<p>71 rows × 15 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -948,17 +981,17 @@
        "15  Block number must be a finalized block or else...   \n",
        "\n",
        "                                                param  \\\n",
-       "1   (timelock_, comp_, votingPeriod_, votingDelay_...   \n",
-       "2   (targets, values, signatures, calldatas, descr...   \n",
-       "3                                        (proposalId)   \n",
-       "5                                        (proposalId)   \n",
-       "6                                        (proposalId)   \n",
+       "1   [timelock_, comp_, votingPeriod_, votingDelay_...   \n",
+       "2   [targets, values, signatures, calldatas, descr...   \n",
+       "3                                        [proposalId]   \n",
+       "5                                        [proposalId]   \n",
+       "6                                        [proposalId]   \n",
        "..                                                ...   \n",
-       "11                              (src, dst, rawAmount)   \n",
-       "12                                        (delegatee)   \n",
-       "13                (delegatee, nonce, expiry, v, r, s)   \n",
-       "14                                          (account)   \n",
-       "15                             (account, blockNumber)   \n",
+       "11                              [src, dst, rawAmount]   \n",
+       "12                                        [delegatee]   \n",
+       "13                [delegatee, nonce, expiry, v, r, s]   \n",
+       "14                                          [account]   \n",
+       "15                             [account, blockNumber]   \n",
        "\n",
        "                                               return  \\\n",
        "1                                                       \n",
@@ -986,10 +1019,10 @@
        "14  https://raw.githubusercontent.com/notchia/meta...  Governor Bravo  \n",
        "15  https://raw.githubusercontent.com/notchia/meta...  Governor Bravo  \n",
        "\n",
-       "[80 rows x 15 columns]"
+       "[71 rows x 15 columns]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1001,7 +1034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1166,7 +1199,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>228 rows × 8 columns</p>\n",
+       "<p>153 rows × 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1209,10 +1242,10 @@
        "45          The address of the account to check  \n",
        "46  The block number to get the vote balance at  \n",
        "\n",
-       "[228 rows x 8 columns]"
+       "[153 rows x 8 columns]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1224,7 +1257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "id": "PzQkImT-uVxV"
    },


### PR DESCRIPTION
- Ignore SafeMath contract; can add other contracts to ignore later
- Remove parameter comments which are duplicates of their parent object's comments
- Save list of parameters found with @param tag in comments