### PR TITLE
Switch from PyPI solidity-parser package to git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "python-solidity-parser"]
+	path = python-solidity-parser
+	url = https://github.com/notchia/python-solidity-parser.git
+	branch = bugfix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "python-solidity-parser"]
-	path = python-solidity-parser
+	path = solidity-parser
 	url = https://github.com/notchia/python-solidity-parser.git
-	branch = bugfix
+	branch = main

--- a/data/repodicts.csv
+++ b/data/repodicts.csv
@@ -21,3 +21,6 @@ kleros,erc-792,master,v8.0.0,2021-10-07T22:13:38Z,https://github.com/kleros/erc-
 jurteam,mvp-smart-contract,master,,2021-12-30T02:31:13Z,https://github.com/jurteam/mvp-smart-contract,jurteam_mvp-smart-contract_master
 
 MolochVentures,moloch,master,,2022-02-01T13:17:27Z,https://github.com/MolochVentures/moloch,MolochVentures_moloch_master
+safe-global,safe-contracts,main,v1.3.0-libs.0,2021-11-17T16:53:12Z,https://github.com/safe-global/safe-contracts/tree/v1.3.0-libs.0,safe-global_safe-contracts_v1.3.0-libs.0
+gnosis,zodiac,master,v1.1.5,2022-09-14T04:32:09Z,https://github.com/gnosis/zodiac/tree/v1.1.5,gnosis_zodiac_v1.1.5
+aragon,core,develop,,2022-09-06T19:24:46Z,https://github.com/aragon/core/tree/develop/packages/contracts/,aragon_core_develop

--- a/governance-surface_factory-contracts.ipynb
+++ b/governance-surface_factory-contracts.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 2,
    "id": "01ff10dc",
    "metadata": {},
    "outputs": [],
@@ -1133,7 +1133,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_43688/2760519353.py:2: SettingWithCopyWarning: \n",
+      "/tmp/ipykernel_49450/2760519353.py:2: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
@@ -1156,7 +1156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "id": "dcfeb247",
    "metadata": {},
    "outputs": [
@@ -1309,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 16,
    "id": "121ad97c",
    "metadata": {},
    "outputs": [
@@ -1431,7 +1431,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_43688/2615755141.py:5: SettingWithCopyWarning: \n",
+      "/tmp/ipykernel_49450/3429132991.py:6: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -1455,7 +1455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 17,
    "id": "ccf06f46",
    "metadata": {},
    "outputs": [
@@ -1518,7 +1518,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_43688/3706757327.py:6: SettingWithCopyWarning: \n",
+      "/tmp/ipykernel_49450/3706757327.py:6: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -1543,7 +1543,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('metagov')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/metagov/__init__.py
+++ b/metagov/__init__.py
@@ -1,0 +1,2 @@
+import sys
+sys.path.append("solidity-parser")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ requests
 scikit-learn
 scipy
 seaborn
-solidity_parser
 validators


### PR DESCRIPTION
PyPI doesn't have a bugfix that is included in the newer main branch of the repository: https://github.com/ConsenSys/python-solidity-parser/commit/5b0977c4a986f0177260f315e77d77d26a2c6510

So, switch to including the package as a git submodule to be able to use the most recent version (currently points to main of my fork of the repo).

Also add the following to the repos CSV:
- Moloch
- GnosisSafe
- Zodiac
- Aragon Core